### PR TITLE
Adding CentOS-7.7.1908-aarch64 to cobbler

### DIFF
--- a/cobbler.yml
+++ b/cobbler.yml
@@ -32,6 +32,7 @@
     - { role: cobbler_profile, distro_name: CentOS-7.7-x86_64, tags: ['centos7.7'] }
     - { role: cobbler_profile, distro_name: CentOS-8.0-x86_64, tags: ['centos8.0'] }
     - { role: cobbler_profile, distro_name: CentOS-8.1-x86_64, tags: ['centos8.1'] }
+    - { role: cobbler_profile, distro_name: CentOS-7.7-aarch64, tags: ['centos7.7-aarch64'] }
     - { role: cobbler_profile, distro_name: CentOS-8.1-aarch64, tags: ['centos8.1-aarch64'] }
     - { role: cobbler_profile, distro_name: Ubuntu-12.04-server-x86_64, tags: ['ubuntu-precise'] }
     - { role: cobbler_profile, distro_name: Ubuntu-14.04-server-x86_64, tags: ['ubuntu-trusty'] }

--- a/roles/cobbler_profile/defaults/main.yml
+++ b/roles/cobbler_profile/defaults/main.yml
@@ -88,6 +88,11 @@ distros:
       iso: http://mirror.linux.duke.edu/pub/centos/8.1.1911/isos/x86_64/CentOS-8.1.1911-x86_64-dvd1.iso
       sha256: 3ee3f4ea1538e026fff763e2b284a6f20b259d91d1ad5688f5783a67d279423b
       kickstart: cephlab_rhel.ks
+  "CentOS-7.7-aarch64":
+      iso: https://mirrors.huaweicloud.com/centos-altarch/7.7.1908/isos/aarch64/CentOS-7-aarch64-Everything-1908.iso
+      sha256: 2b0c79d5fec09bf1b88782ac58c9c048cc988ffd884bcd59b6f7ba22c69203cb 
+      kickstart: cephlab_rhel.ks
+      arch: aarch64
   "CentOS-8.1-aarch64":
       iso: http://mirror.linux.duke.edu/pub/centos/8/isos/aarch64/CentOS-8.1.1911-aarch64-dvd1.iso
       sha256: 357f34e86a28c86aaf1661462ef41ec4cf5f58c120f46e66e1985a9f71c246e3


### PR DESCRIPTION
Adding CentOS-7.7.1908-aarch64 to cobbler

Signed-off-by: chuqifang <chuqifang@hisilicon.com>