### PR TITLE
Adding Ubuntu-18.04-aarch64 to cobbler

### DIFF
--- a/cobbler.yml
+++ b/cobbler.yml
@@ -38,6 +38,7 @@
     - { role: cobbler_profile, distro_name: Ubuntu-15.04-server-x86_64, tags: ['ubuntu-vivid'] }
     - { role: cobbler_profile, distro_name: Ubuntu-16.04-server-x86_64, tags: ['ubuntu-xenial'] }
     - { role: cobbler_profile, distro_name: Ubuntu-18.04-server-x86_64, tags: ['ubuntu-bionic'] }
+    - { role: cobbler_profile, distro_name: Ubuntu-18.04-server-aarch64, tags: ['ubuntu-bionic-aarch64'] }
     - { role: cobbler_profile, distro_name: openSUSE-15.0-x86_64, tags: ['opensuse-15.0'] }
     - { role: cobbler_profile, distro_name: openSUSE-15.1-x86_64, tags: ['opensuse-15.1'] }
     - { role: cobbler_profile, distro_name: openSUSE-15.2-x86_64, tags: ['opensuse-15.2'] }

--- a/roles/cobbler_profile/defaults/main.yml
+++ b/roles/cobbler_profile/defaults/main.yml
@@ -123,6 +123,12 @@ distros:
       kickstart: cephlab_ubuntu.preseed
       kernel_options: "netcfg/choose_interface=auto console=tty0 console=ttyS1,115200 GRUB_DISABLE_OS_PROBER=true"
       kernel_options_post: "pci=realloc=off console=tty0 console=ttyS1,115200"
+  "Ubuntu-18.04-server-aarch64":
+      iso: "https://mirrors.huaweicloud.com/ubuntu-cdimage/ubuntu/releases/18.04/release/ubuntu-18.04.4-server-arm64.iso"
+      sha256: 8eb3c1866ca3b68e4cd22ec9d7c02f97f4d2b3713447370f3c252a4189116824
+      kickstart: cephlab_ubuntu.preseed
+      kernel_options: "netcfg/choose_interface=auto console=tty0 console=ttyS1,115200 GRUB_DISABLE_OS_PROBER=true"
+      kernel_options_post: "pci=realloc=off console=tty0 console=ttyS1,115200"
   "openSUSE-15.0-x86_64":
       iso: "https://download.opensuse.org/distribution/leap/15.0/iso/openSUSE-Leap-15.0-DVD-x86_64.iso"
       sha256: c477428c7830ca76762d2f78603e13067c33952b936ff100189523e1fabe5a77


### PR DESCRIPTION
Adding Ubuntu-18.04-aarch64 to cobbler

Signed-off-by: chuqifang <chuqifang@hisilicon.com>